### PR TITLE
Corrected bulk loader code to auto-load the alias types/kinds found i…

### DIFF
--- a/src/main/java/com/labsynch/cmpdreg/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/cmpdreg/service/BulkLoadServiceImpl.java
@@ -954,7 +954,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		lookUpStringList = getStringValuesFromMappings(mol, lookUpProperty, mappings);
 
 		if (lookUpStringList != null && !lookUpStringList.isEmpty()){
-			String aliasType = "external id";
+			String aliasType = "External ID";
 			String aliasKind = "LiveDesign Corp Name";
 			for (String lookUpStringEntry : lookUpStringList){
 				parent = addParentAlias(parent, aliasType, aliasKind, lookUpProperty, lookUpStringEntry);
@@ -968,7 +968,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		lookUpStringList = getStringValuesFromMappings(mol, lookUpProperty, mappings);
 		if (lookUpStringList != null && !lookUpStringList.isEmpty()){
 			String aliasType = "other name";
-			String aliasKind = "Parent Common Name";
+			String aliasKind = "Common Name";
 			for (String lookUpStringEntry : lookUpStringList){
 				parent = addParentAlias(parent, aliasType, aliasKind, lookUpProperty, lookUpStringEntry);
 				logger.info("------------- adding alias set to the parent -------------------");

--- a/src/main/resources/db/migration/postgres/V1.1.0.0__fix_parent_alias_type_kinds.sql
+++ b/src/main/resources/db/migration/postgres/V1.1.0.0__fix_parent_alias_type_kinds.sql
@@ -1,0 +1,2 @@
+UPDATE parent_alias SET ls_type = 'External ID' where ls_type = 'external id';
+UPDATE parent_alias SET ls_kind = 'Common Name' where ls_kind = 'Parent Common Name';


### PR DESCRIPTION
…n the flyway migration V1.0.4.0__add_parentaliastypekinds.sql. Also added a flyway migration to fix any aliases loaded with the legacy types/kinds that do not match the data dictionary values