### PR TITLE
Found issue where tautomer search was not recognizing tautomers when …

### DIFF
--- a/src/main/java/com/labsynch/cmpdreg/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
+++ b/src/main/java/com/labsynch/cmpdreg/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
@@ -221,9 +221,9 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 			
 			if (useStandardizer){
 				mol = standardizeMolecule(mol);
-				mol.aromatize();				
+				mol.dearomatize();				
 			} else {
-				mol.aromatize();				
+				mol.dearomatize();				
 			}
 
 			logger.debug("definition of exact search: " + exactSearchDef);
@@ -289,6 +289,16 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 			//TODO: should do an audit of the search types being used by CReg.
 			
 			List<Integer> hitListList = query.getResultList();
+			
+			//if we are searching in DUPLICATE_TAUTOMER mode and the above TAU search returned results
+			//we need to also check the stereochemistry matches since we can't do both at once.
+			//the overall results should be the intersection of both queries
+			if (hitListList.size() > 0 && searchType.toUpperCase().equals("DUPLICATE_TAUTOMER")) {
+				query.setParameter("parameters", "STE");
+				List<Integer> stereoHitListList = query.getResultList();
+				hitListList.retainAll(stereoHitListList);
+			}
+			
 			
 			if (hitListList.size() > 0){
 				logger.debug("found a matching molecule!!!  " + hitListList.size());


### PR DESCRIPTION
…the structures were aromatized. Fixed by always dearomatizing query structures rather than aromatizing them. Fixes #22

Another issue is that bingo cannot run stereo-sensitive (duplicate) searches with the tautomer (TAU) flag also on. Achieved the DUPLICATE_TAUTOMER setting by first running a tautomer search, then running a stereo search, and intersecting the results. This allows for tautomers with no stereochemistry to still be matched, while stereoisomers (which match in the tautomer search), to be differentiated (do not match in stereo-sensitive search). Fixes #21