### PR TITLE
Fixed faulty logic in parent matching in Bulk Loader in case where co…

### DIFF
--- a/src/main/java/com/labsynch/cmpdreg/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/cmpdreg/service/BulkLoadServiceImpl.java
@@ -564,7 +564,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 					boolean sameCorpName = (parent.getCorpName() != null && parent.getCorpName().equals(foundParent.getCorpName()));
 					boolean noCorpName = (parent.getCorpName() == null);
 					boolean sameCorpPrefixOrNoPrefix = (parent.getLabelPrefix() == null || foundParent.getCorpName().contains(parent.getLabelPrefix().getLabelPrefix()));
-					if (sameStereoCategory & sameStereoComment & (sameCorpName | noCorpName) & sameCorpPrefixOrNoPrefix){
+					if (sameStereoCategory & sameStereoComment & (sameCorpName | (noCorpName & sameCorpPrefixOrNoPrefix))){
 						//parents match
 						parent = foundParent;
 						break searchResultLoop;


### PR DESCRIPTION
…rporate ID is mapped in, structure, corp name, stereo category and stereo comments all match, but the system is in Label Prefix / ACASLabelSequence mode. Fixes #46