### PR TITLE
Better behavior when CReg generates a corpName that was already taken

### DIFF
--- a/src/main/java/com/labsynch/cmpdreg/domain/CorpName.java
+++ b/src/main/java/com/labsynch/cmpdreg/domain/CorpName.java
@@ -218,6 +218,26 @@ public class CorpName {
 		Matcher matcher = pattern.matcher(corpName);
 		return (matcher.replaceFirst("$1"));
 	}
+	
+	/**
+	 * Takes a string and returns the numeric value of the longest numeric substring, or 0 if the string has no numerals
+	 * @param corpName The corporate ID string
+	 * @return the Long value of the corp number parsed
+	 */
+	public static Long parseParentNumber(String corpName){
+		//Returns the numeric value of the largest numeric substring of the input string, or 0 if one cannot be parsed
+		String longestSub = "";
+		for (String sub : corpName.split("[^0-9]")){
+			if (sub.length() > longestSub.length()){
+				longestSub = sub;
+			}
+		}
+		if (longestSub.length() > 0){
+			return Long.parseLong(longestSub);
+		}else {
+			return 0L;
+		}
+	}
 
 	public static Long parseCorpNumber(String corpName) {
 		corpName = corpName.trim();

--- a/src/main/java/com/labsynch/cmpdreg/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/cmpdreg/service/MetalotServiceImpl.java
@@ -328,6 +328,10 @@ public class MetalotServiceImpl implements MetalotService {
 						generateAndSetCorpName(parent);
 						corpNameAlreadyExists = checkCorpNameAlreadyExists(parent.getCorpName());
 					}
+					//try to set the parentNumber if it is not set already
+					if (parent.getParentNumber() < 1){
+						parent.setParentNumber(CorpName.parseParentNumber(parent.getCorpName()));
+					}
 					logger.debug("Saving new parent with corp name "+parent.getCorpName()+" and parent number "+parent.getParentNumber());
 					parent.persist();
 				} 

--- a/src/main/java/com/labsynch/cmpdreg/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/cmpdreg/service/MetalotServiceImpl.java
@@ -323,15 +323,13 @@ public class MetalotServiceImpl implements MetalotService {
 
 					parent.setMolFormula(chemService.getMolFormula(parent.getMolStructure()));
 					//add unique constraint to parent corp name as well (parent and lot)
-					try {
-						logger.debug("Saving new parent with corp name "+parent.getCorpName()+" and parent number "+parent.getParentNumber());
-						parent.persist();
-					} catch (Exception e){
-						logger.error("Caught an exception saving the parent: " + e);
-						//get a new corp name and try saving again
+					boolean corpNameAlreadyExists = checkCorpNameAlreadyExists(parent.getCorpName());
+					while (corpNameAlreadyExists) {
 						generateAndSetCorpName(parent);
-						parent.persist();
+						corpNameAlreadyExists = checkCorpNameAlreadyExists(parent.getCorpName());
 					}
+					logger.debug("Saving new parent with corp name "+parent.getCorpName()+" and parent number "+parent.getParentNumber());
+					parent.persist();
 				} 
 			}
 
@@ -814,6 +812,14 @@ public class MetalotServiceImpl implements MetalotService {
 			CorpNameDTO corpName = CorpName.generateParentNameFromSequence();
 			parent.setCorpName(corpName.getCorpName());
 			parent.setParentNumber(corpName.getCorpNumber());
+		}
+	}
+	
+	private boolean checkCorpNameAlreadyExists(String corpName) {
+		if (Parent.countFindParentsByCorpNameEquals(corpName) > 0L){
+			return true;
+		}else {
+			return false;
 		}
 	}
 

--- a/src/main/resources/db/migration/postgres/V1.2.2.0__fill_in_parent_number.sql
+++ b/src/main/resources/db/migration/postgres/V1.2.2.0__fill_in_parent_number.sql
@@ -1,0 +1,7 @@
+UPDATE parent SET parent_number = new_parent_number FROM (
+SELECT corp_name, parent_number, ordered_nums[1]::bigint as new_parent_number FROM (
+SELECT corp_name, parent_number, array_agg(parsed_corp_number order by length(parsed_corp_number) DESC) as ordered_nums from (
+select corp_name, parent_number, regexp_split_to_table(corp_name, '[^0-9]') as parsed_corp_number 
+from parent) a
+group by corp_name, parent_number) b) c
+WHERE c.corp_name = parent.corp_name AND parent.parent_number = 0;

--- a/src/test/java/com/labsynch/cmpdreg/service/CustomCorpNameTest.java
+++ b/src/test/java/com/labsynch/cmpdreg/service/CustomCorpNameTest.java
@@ -1,11 +1,12 @@
 package com.labsynch.cmpdreg.service;
 
-import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -17,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.labsynch.cmpdreg.domain.CorpName;
 import com.labsynch.cmpdreg.domain.Lot;
-
-import org.junit.Assert;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = "classpath:/META-INF/spring/applicationContext*.xml")
@@ -107,5 +106,20 @@ public class CustomCorpNameTest {
 		String output = CorpName.generateCorpLicensePlate();
 		logger.info("custom license plate: " + output);
 
+	}
+	
+	@Test
+	public void parseCorpNameTest(){
+		Map<String, Long> corpNames = new HashMap<String, Long>();
+		corpNames.put("CMPD-0001234", 1234L);
+		corpNames.put("CMPD-0001", 1L);
+		corpNames.put("CMPD0001234", 1234L);
+		corpNames.put("CMP1-001234", 1234L);
+		corpNames.put("CMP1-001234-001A", 1234L);
+		corpNames.put("CMPDTHEBESTNONUMBERS", 0L);
+		for(String corpName : corpNames.keySet()){
+			Long parentNumber = CorpName.parseParentNumber(corpName);
+			Assert.assertEquals(corpNames.get(corpName), parentNumber);
+		}
 	}
 }


### PR DESCRIPTION
Added a check to MetalotServiceImpl to see if newly generated parent corpName already exists. If the corpName already exists, the service will now keep generating corpNames and re-checking until it finds a unique one. This replaces logic that only re-tried once and then errored out. Useful for cases when users are loading SDF's with corporate IDs preassigned.