### PR TITLE
Fixes #50 , logical bug in single registration where boolean "queryPa…

### DIFF
--- a/src/main/java/com/labsynch/cmpdreg/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/cmpdreg/service/MetalotServiceImpl.java
@@ -225,7 +225,7 @@ public class MetalotServiceImpl implements MetalotService {
 									//parent structure and stereo category matches
 									//determine if Stereo Comment is different
 									boolean parentHasStereoComment = (parent.getStereoComment() != null && parent.getStereoComment().length() > 0);
-									boolean queryParentHasStereoComment = (queryParent.getStereoComment() == null && queryParent.getStereoComment().length() > 0);
+									boolean queryParentHasStereoComment = (queryParent.getStereoComment() != null && queryParent.getStereoComment().length() > 0);
 									if (!parentHasStereoComment & !queryParentHasStereoComment){
 										//both stereo comments are null => dupes
 										dupeParentCount++;


### PR DESCRIPTION
…rentHasStereoComment" is being generated wrong. A parent should "have stereo comment" if the stereoComment is NOT null and has length > 0.