### PR TITLE
fixes #62: upgrade postgres to match acas-roo-server for postgres 10 compatability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,9 +257,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.1-901-1.jdbc4</version>
+			<version>9.4.1212.jre7</version>
 		</dependency>
 		<!-- http://mvnrepository.com/artifact/net.sourceforge.jtds/jtds -->
 		<dependency>


### PR DESCRIPTION
Not upgrading to latest driver because acas-roo-server is also on this postgres version and keeping them inline is important for when we merge with that project.